### PR TITLE
output "No synth app detected"  in non-synth-app directory

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -62,7 +62,13 @@ exports.startServer = function (mode, port) {
     });
   };
   var startServer = function (restarted) {
-    var app = requireUncached(path.join(process.cwd(), 'back/back-app'));
+    var app;
+    try {
+      app = requireUncached(path.join(process.cwd(), 'back/back-app'));
+    } catch (err) {
+      console.log('No synth app detected.');
+      process.exit(1)
+    }
     if (app && typeof app.listen == 'function') {
       server = app.listen(port, function () {
         serverRunning = true;


### PR DESCRIPTION
Thrown error in requiring `back/back-app` was not catched.
So error message was such a mess.

```
$ synth s

module.js:340
    throw err;
    ^
Error: Cannot find module '/home/kumagi/back/back-app'
  at Function.Module._resolveFilename (module.js:338:15)
  at Function.require.resolve (module.js:384:19)
  at requireUncached (/path/to/synth/synth/lib/requireUncached.js:16:14)
  at startServer (/path/to/synth/synth/lib/commands.js:65:15)
  at Object.exports.startServer (/path/to/synth/synth/lib/commands.js:95:5)
  at Object.<anonymous> (/path/to/synth/synth/bin/synth:64:12)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Function.Module.runMain (module.js:497:10)
  at startup (node.js:119:16)
  at node.js:902:3
```

It should be

```
$ synth s
No synth app detected.
```

Thanks.
