### PR TITLE
ng-min depricated use ng-annotate instead.

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -2,7 +2,7 @@ var fs = require('fs'),
     path = require('path'),
     coffee = require('coffee-script'),
     uglify = require('uglify-js'),
-    ngmin = require('ngmin'),
+    ngannotate = require('ng-annotate'),
     sass = require('node-sass'),
     stylus = require('stylus'),
     CleanCSS = require('clean-css');
@@ -80,7 +80,7 @@ exports.jsPrecompiled = function () {
   });
 
   // If any of the code is from angularjs, make it safe for minification
-  jsPrecompiled = ngmin.annotate(jsPrecompiled);
+  jsPrecompiled = ngannotate(jsPrecompiled, {add: true}).src;
 
   jsPrecompiled = uglify.minify(jsPrecompiled, { fromString: true }).code;
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "npm": "^1.3.23",
     "uglify-js": "^2.4.12",
     "coffee-script": "^1.7.1",
-    "ngmin": "^0.5",
+    "ng-annotate": "^0.9.8",
     "node-sass": "^0.9",
     "clean-css": "^2.0.7",
     "stylus": "^0.45",


### PR DESCRIPTION
see https://github.com/btford/ngmin and https://github.com/olov/ng-annotate#how-does-ng-annotate-compare-to-ngmin

Fix for issue: https://github.com/JonAbrams/synth/issues/37
