### PR TITLE
forgot to add body-parser to package.json, needed for params service

### DIFF
--- a/templates/back/mongojs/package.json
+++ b/templates/back/mongojs/package.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "synth": "^${ synthVersion }",
     "promised-mongo": "^0.11",
-    "bluebird": "^1.0.3"
+    "bluebird": "^1.0.3",
+    "body-parser": "^1.6.3"
   },
   "devDependencies": {
   }


### PR DESCRIPTION
Missed this file when adding the params service (or rather reverting from having the get single tweet in template)
