### PR TITLE
Modify the way to use the Lodash

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -245,7 +245,10 @@ function applyTemplate ( direction, template, dest ) {
         fs.unlinkSync(filePath); // Delete the file
         filePath = path.join(destPath, '.gitignore');
       }
-      fs.writeFileSync( filePath, _.template(contents, tokens) );
+      if (_.VERSION.split('.')[0] > 2)
+        fs.writeFileSync( filePath, _.template(contents)(tokens) );
+      else
+        fs.writeFileSync( filePath, _.template(contents, tokens) );
     } catch (err) {
       if (err.code != 'EISDIR') throw err;
     }


### PR DESCRIPTION
The API of Lodash had been update after the version 2.4.1, so modify the way to call the template method by the version of Lodash.